### PR TITLE
Setup Continuous Integration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: nix
+
+script: nix-build --arg coq-version "\"$COQ_VERSION\"" --extra-substituters https://coq.cachix.org --trusted-public-keys "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= coq.cachix.org-1:Jgt0DwGAUo+wpxCM52k2V+E0hLoOzFPzvg94F65agtI="
+
+env:
+#  - COQ_VERSION=master
+#  - COQ_VERSION=v8.8
+#  - COQ_VERSION=8.8
+  - COQ_VERSION=8.7

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,16 @@
+{ coq-version ? "8.7" }:
+
+let coq = {
+#  "master" = import (fetchTarball "https://github.com/coq/coq/tarball/master") {};
+#  "v8.8" = import (fetchTarball "https://github.com/coq/coq/tarball/v8.8") {};
+#  "8.8" = (import <nixpkgs> {}).coq_8_8;
+  "8.7" = (import <nixpkgs> {}).coq_8_7;
+  }."${coq-version}";
+in
+
+(import <nixpkgs> {}).stdenv.mkDerivation rec {
+  name = "bertrand";
+  buildInputs = [ coq ];
+  src = ./.;
+  installFlags = "DESTDIR=$(out)/lib/coq/";
+}


### PR DESCRIPTION
For now, bertrand is only compatible with Coq 8.7 (cf. #1).

The CI system is the same one as in coq-community/qarith-stern-brocot#2